### PR TITLE
Fix backend instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ cd aethra
 
 ### 2. Install Python dependencies (optional backend):
 
+From the repository root (where `server.py` lives):
+
 ```bash
-cd aethra-backend
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- update Python setup section to run from repo root

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68434956803083258aac18d272118fba